### PR TITLE
Add support for psycopg3

### DIFF
--- a/fernet_fields/fields.py
+++ b/fernet_fields/fields.py
@@ -120,7 +120,10 @@ class EncryptedEmailField(EncryptedField, models.EmailField):
 
 
 class EncryptedIntegerField(EncryptedField, models.IntegerField):
-    pass
+    def get_db_prep_save(self, value, connection):
+        if value is not None:
+            retval = self.fernet.encrypt(force_bytes(value))
+            return connection.Database.Binary(retval)
 
 
 class EncryptedDateField(EncryptedField, models.DateField):


### PR DESCRIPTION
- Fix psycopg3 error

```python
    def adapt_integerfield_value(self, value, internal_type):
        if value is None or hasattr(value, "resolve_expression"):
            return value
>       return self.integerfield_type_map[internal_type](value)
E       KeyError: 'BinaryField'
```